### PR TITLE
Fix issue #12 - Max number of dwellings too low

### DIFF
--- a/app/src/main/res/layout/fragment_family.xml
+++ b/app/src/main/res/layout/fragment_family.xml
@@ -29,7 +29,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         caverna:min="0"
-        caverna:max="3"
+        caverna:max="4"
         caverna:label="@string/dwellings"
         caverna:icon="@drawable/dwelling" />
 


### PR DESCRIPTION
Update the dwellings slider in the family tab to support 4 dwellings.